### PR TITLE
Correct deployment instructions

### DIFF
--- a/Instructions/Labs/01-interact-with-an-api.md
+++ b/Instructions/Labs/01-interact-with-an-api.md
@@ -235,7 +235,9 @@ The tool will create the necessary resources in Azure and compile the code.
 
 ### Task 3: Deploy the web app and browse the running site
 
-1. After the resources are create and the code has completed compiling a window will pop-up prompting you to **Deploy**, select the **Deploy** option. 
+1. After the resources are created in the cloud environment, a notification message will appear in the Azure Activity Log tab ("Create Web App .. Succeeded").
+
+1. Expand the Azure Resources overview and select the newly created Web app. Click **Deploy to Web App** 
 
     The system will build a release version of the code and deploy it to the resources you created earlier.
 


### PR DESCRIPTION
The existing instructions assume the web app deployment is already linked for deployments through a git commit hook. However these instructions start out by having the student download a zipfile, therefore the source is not linked to a git repository and the deployment needs to be initiated manually from local source.

## Lab/Demo: 01

Changes proposed in this pull request:

- Have student initiate deployment manually instead, since commit hook is not in place