### PR TITLE
Adding required Azure App Service VS Code extension

### DIFF
--- a/Instructions/Labs/01-interact-with-an-api.md
+++ b/Instructions/Labs/01-interact-with-an-api.md
@@ -194,6 +194,7 @@ When you are ready to move to the next section of the exercise:
 In this section you:
 
 * Use the Azure Resources extension to publish the API to Azure App Service
+* Use the [Azure App Service extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice) to "Create new web app"
 
 ### Task 1: Sign in to Azure
 

--- a/Instructions/Labs/01-interact-with-an-api.md
+++ b/Instructions/Labs/01-interact-with-an-api.md
@@ -240,6 +240,11 @@ The tool will create the necessary resources in Azure and compile the code.
 
     The system will build a release version of the code and deploy it to the resources you created earlier.
 
+1. If no popup shows up, find the App Service resource from Azure Resources extension.
+   1. Make sure the project directory is managed by git.
+   2. Right click Deployments -> Select "Configure Deployment Source" -> Select "LocalGit".
+   3. Right click the App Service app -> Click "Deploy".
+
 1. When the deployment has completed a new pop-up will appear with the option to **Browse Website**, select **Browse Website**.
 
 1. In the browser window that opens add `/swagger` to the end of the URL. 


### PR DESCRIPTION
Otherwise, user will be stuck and can't find the "Create new web app" option.

# Module: APL-2002-develop-aspnet-core-consumes-api
## Lab/Demo: Lab1

Changes proposed in this pull request:

- Adding required extension.